### PR TITLE
fix: use light footer link hover color with dark theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,16 +7,15 @@
 
 /* You can override the default Infima variables here. */
 :root {
---ifm-color-primary: #02204f;
---ifm-color-primary-dark: #021d47;
---ifm-color-primary-darker: #021b43;
---ifm-color-primary-darkest: #011637;
---ifm-color-primary-light: #022357;
---ifm-color-primary-lighter: #02255b;
---ifm-color-primary-lightest: #032a67;
+  --ifm-color-primary: #02204f;
+  --ifm-color-primary-dark: #021d47;
+  --ifm-color-primary-darker: #021b43;
+  --ifm-color-primary-darkest: #011637;
+  --ifm-color-primary-light: #022357;
+  --ifm-color-primary-lighter: #02255b;
+  --ifm-color-primary-lightest: #032a67;
+  --ifm-footer-link-hover-color: var(--ifm-color-secondary);
   --ifm-code-font-size: 90%;
-
-
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
The default footer link hover color is a bit too dark when used with the dark theme so I changed it to be the same as the non-hover color.

## Before
![image](https://user-images.githubusercontent.com/4295266/109683924-b3a21280-7b77-11eb-8259-dae3ecc44477.png)

## After
![image](https://user-images.githubusercontent.com/4295266/109684052-ce748700-7b77-11eb-9e30-ce26497e2701.png)

