### PR TITLE
docs: Fixed URL

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -6,7 +6,7 @@ title: How-to-Guides
 Practical step-by-step guides to help you achieve a specific goal. Most useful when you're trying to get something done. 
 
 ### Local Development
-- [How to spin up a DHIS2 local instance](./guides/spin-up-local-instance)
+- [How to spin up a DHIS2 local instance](./spin-up-local-instance)
 - How to create a new DHIS2 application from scratch - [Watch this short video](https://youtu.be/oi9mSa62G0Q?t=497)
 
 ### Fetching data

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -6,7 +6,7 @@ title: How-to-Guides
 Practical step-by-step guides to help you achieve a specific goal. Most useful when you're trying to get something done. 
 
 ### Local Development
-- [How to spin up a DHIS2 local instance](./spin-up-local-instance)
+- [How to spin up a DHIS2 local instance](/docs/guides/spin-up-local-instance)
 - How to create a new DHIS2 application from scratch - [Watch this short video](https://youtu.be/oi9mSa62G0Q?t=497)
 
 ### Fetching data
@@ -43,4 +43,3 @@ Practical step-by-step guides to help you achieve a specific goal. Most useful w
 ### Testing 
 - How to test my application for a specific DHIS2 version (with `d2 cluster`)
 - How to write automated tests for my application
-


### PR DESCRIPTION
How to spin up a DHIS2 local instance links to (https://developers.dhis2.org/docs/guides/guides/spin-up-local-instance) instead of (https://developers.dhis2.org/docs/guides/spin-up-local-instance) .