### PR TITLE
chore: update d2 cluster guide

### DIFF
--- a/docs/guides/spin-up-local-instance.md
+++ b/docs/guides/spin-up-local-instance.md
@@ -61,7 +61,7 @@ The `down` command followed by the name of the cluster shuts down all Docker pro
 d2 cluster down 2.35.0
 ```
 
-The command `down --clean` destroys that cluster _and_ clears out all data volumes as well as ephemeral containers: 
+The command `down --clean` destroys that cluster _and also_ clears out all saved configuration, data volumes, and ephemeral containers: 
 
 ```shell
 d2 cluster down 2.35.0 --clean

--- a/docs/guides/spin-up-local-instance.md
+++ b/docs/guides/spin-up-local-instance.md
@@ -53,10 +53,16 @@ username: admin
 password: district
 ```
 
-### Stopping an instance
+### Destroy and cleanup commands    
 
-The `down` command followed by the name of the cluster shuts down all Docker processes connected to that cluster.
+The `down` command followed by the name of the cluster shuts down all Docker processes connected to that cluster (it basically destroys a running container):  
 
 ```shell
 d2 cluster down 2.35.0
+```
+
+The command `down --clean` destroys that cluster _and_ clears out all data volumes as well as ephemeral containers: 
+
+```shell
+d2 cluster down 2.35.0 --clean
 ```


### PR DESCRIPTION
This PR intends add information on the `d2 cluster down --clean` command as suggested ([CLI-26](https://jira.dhis2.org/browse/CLI-26)). 
Please let me know if it makes sense 👍 