### PR TITLE
docs(apphub): don't use DHIS2 logo in app icon

### DIFF
--- a/docs/guides/apphub-guidelines.md
+++ b/docs/guides/apphub-guidelines.md
@@ -36,6 +36,7 @@ Keep the following guidelines in mind when creating an app icon:
 -   Use contrasting colors to make your icon clear at all sizes.
 -   Icons should be uploaded in high-resolution, at least 512×512px in size.
 -   Make sure all images and icons are correctly licensed. Do not take images or icons from a web image search without obtaining a license.
+-   Do not use the DHIS2 logo in your app icon. The DHIS2 logo is a protected asset and we ask you not to modify it.
 
 ### Description
 


### PR DESCRIPTION
This came up during a review of an app on the App Hub. Even though it is mentioned where the logo is download from the [https://github.com/dhis2/dhis2-identity#dont-add-other-shapes-to-the-logo](dhis2-identity-repo) it is under "best practices" and might be misunderstood/not taken seriously. I think it should be mentioned here as well.