### PR TITLE
docs: add link to dhis2.org main site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,6 +66,10 @@ module.exports = {
               label: "Blog",
               to: "docs/",
             },
+            {
+              label: "DHIS2.org",
+              to: "https://dhis2.org",
+            },
           ],
         },
       ],


### PR DESCRIPTION
There's currently no way to get back to dhis2.org from developers.dhis2.org - this just adds a link to the footer, though we may want to add something more prominent in the header..?