### PR TITLE
docs: design system figma library announcement

### DIFF
--- a/blog/2021-07-20-design-system-figma-library.md
+++ b/blog/2021-07-20-design-system-figma-library.md
@@ -7,13 +7,11 @@ author_image_url: https://avatars.githubusercontent.com/u/33054985?s=400&u=0fa29
 tags: [design, developer tools]
 ---
 
-The [DHIS2 Design System](https://github.com/dhis2/design-system) is now available as a [Figma Community library](/).
-<!-- LINK PENDING -->
+The [DHIS2 Design System](https://github.com/dhis2/design-system) is now available as a [Figma Community library](https://www.figma.com/community/file/999207206720939258/DHIS2-Design-System).
 
 <!--truncate-->
 
-**[Click here to open the library in the Figma Community](/)**.
-<!-- LINK PENDING -->
+**[Click here to open the library in the Figma Community](https://www.figma.com/community/file/999207206720939258/DHIS2-Design-System)**.
 
 The file has Design System components, colors and example layouts that you can use in your Figma files. Build realistic, interactive prototypes with all the same components and elements that are available in the DHIS2 Design System and UI.
 

--- a/blog/2021-07-20-design-system-figma-library.md
+++ b/blog/2021-07-20-design-system-figma-library.md
@@ -1,0 +1,43 @@
+---
+slug: design-system-figma-library
+title: Design System Figma library available now
+author: Joe Cooper
+author_url: https://github.com/cooper-joe
+author_image_url: https://avatars.githubusercontent.com/u/33054985?s=400&u=0fa29eea95dc43633e26bd41f871524bdee4b07a&v=4
+tags: [design, developer tools]
+---
+
+The [DHIS2 Design System](https://github.com/dhis2/design-system) is now available as a [Figma Community library](/).
+<!-- LINK PENDING -->
+
+<!--truncate-->
+
+**[Click here to open the library in the Figma Community](/)**.
+<!-- LINK PENDING -->
+
+The file has Design System components, colors and example layouts that you can use in your Figma files. Build realistic, interactive prototypes with all the same components and elements that are available in the DHIS2 Design System and UI.
+
+New to Figma and want to start prototyping and designing DHIS2 applications? [Click here to check out Figma's getting started guide](https://help.figma.com/hc/en-us/categories/360002042553-Figma-design#Get-started-with-Figma-design).
+
+## How to use the Figma library?
+
+**If you have a paid Figma account**
+
+Users with a paid Figma account can duplicate the community library and use it as a *shared library*. This gives you access to all the components and colors in all your Figma files. [Click here to learn about libraries in Figma](https://help.figma.com/hc/en-us/sections/4403936000407-Libraries-).
+
+**If you have a free Figma account**
+
+Users with a free Figma account can still use the Design System library. Duplicate the file to your Figma workspace, then copy and paste the components you want to use into your Figma file. Each component Figma page has a reference *sticker sheet* where example components can be copy and pasted from.
+
+Check out the *Readme* page in the Figma file for more details about components, colors and fonts.
+
+## Organization
+Each component or element, like *Button* or *Colors*, is set up as a page in the Figma file. Every page has an overview with links to documentation, live demos and example components for quick copying to your files.
+
+## Functionality
+[Component variants](https://help.figma.com/hc/en-us/articles/360056440594-Create-and-use-variants) are used to make the Figma components flexible but manageable. Most components are a single element with multiple variants that offer different sizes, states and types. Check out the variants panel in the right sidebar when viewing the components to see which variants are available.
+
+Complex components, like the Transfer and the Organization unit tree, are built as example components with multiple sub-components. The common use cases for these components are provided as example components. The sub-components can be combined to make different types of these complex components.
+
+## Updates and changes
+The library will be updated with new and adjusted components as they are added to the Design System. Duplicated Figma files don't update automatically, so check back occasionally to update your copy of the Design System.


### PR DESCRIPTION
This PR adds a blog post announcing the Design System Figma community library. The post contains a short overview of the library and some guidelines to get started. 

This PR is opened in draft as the final, released library link isn't available yet, but the rest of the content can be reviewed.

I also thought it might be useful to provide a link to the figma file somewhere permanent, rather than a time-based blog post. Thinking a kind of "Resources" section. I'm not sure which section fits this best, maybe _Reference_? What do you both think?