### PR TITLE
fix: update d2-style commands format

### DIFF
--- a/docs/guides/code-style.md
+++ b/docs/guides/code-style.md
@@ -39,8 +39,8 @@ Then, add the following scripts to `package.json`:
     // ...
     "scripts": {
         // ...
-        "lint": "d2-style js check && d2-style text check",
-        "format": "d2-style js apply && d2-style text apply"
+        "lint": "d2-style check js && d2-style check text",
+        "format": "d2-style apply js && d2-style apply text"
     }
 }
 ```


### PR DESCRIPTION
In version [8.0.0](https://github.com/dhis2/cli-style/blob/master/CHANGELOG.md#800-2021-05-05), d2-style's `check` and `apply` command verbs were moved to the top level.