### PR TITLE
feat: domain navigation bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,6 +75,13 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} The DHIS2 Core Team`,
     },
+    announcementBar: {
+      content: '<a href="https://www.dhis2.org" target="_blank" rel="noopener" class="domain-nav-item" >DHIS2.org</a > <a href="https://play.dhis2.org" target="_blank" rel="noopener" class="domain-nav-item" >Demo</a > <a href="https://docs.dhis2.org/" target="_blank" rel="noopener" class="domain-nav-item" >Documentation</a > <a href="https://community.dhis2.org" target="_blank" rel="noopener" class="domain-nav-item" >Community</a >',
+      backgroundColor: '#f8fafc',
+      textColor: '#051841',
+      isCloseable: false,
+      id: 'domainNav',
+    },
     googleAnalytics: {
       trackingID: 'UA-157707339-4',
       anonymizeIP: true

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -65,3 +65,27 @@
   left: 0px;
   color: #a0adba;
 }
+
+/* Change domain nav position and styling */
+.announcementBarContent_node_modules-\@docusaurus-theme-classic-lib-next-theme-AnnouncementBar-, .announcementBarContent_2EqR {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.announcementBarContent_node_modules-\@docusaurus-theme-classic-lib-next-theme-AnnouncementBar- a.domain-nav-item, .announcementBarContent_2EqR a.domain-nav-item {
+  font-size: 12px;
+  padding: 0 8px;
+  text-decoration: none;
+  margin-left: 8px;
+  flex-shrink: 0;
+}
+
+.announcementBarContent_node_modules-\@docusaurus-theme-classic-lib-next-theme-AnnouncementBar- a.domain-nav-item:hover, .announcementBarContent_2EqR a.domain-nav-item:hover {
+  text-decoration: underline;
+}
+
+a.domain-nav-item:after {
+  padding-left: 4px;
+  content: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjciIHZpZXdCb3g9IjAgMCA3IDciPgogIDxwYXRoIGZpbGw9IiMyOTNGNkYiIGQ9Ik03LDAgTDcsNCBMNiw0IEw1Ljk5OTQ0NjYxLDEuNzA3IEwxLjM1MzU1MzM5LDYuMzUzNTUzMzkgTDAuNjQ2NDQ2NjA5LDUuNjQ2NDQ2NjEgTDUuMjkyNDQ2NjEsMSBMMywxIEwzLDAgTDcsMCBaIi8+Cjwvc3ZnPgo=');
+}


### PR DESCRIPTION
This PR adds a *domain navigation bar*, as used on other DHIS2 sites. This aligns the Developer Portal with other DHIS2 domains and provides quick navigation between domains.

## Question
This implementation uses the [Docusaurus `AnnouncementBar`](https://docusaurus.io/docs/api/themes/configuration#announcement-bar). This is a simple implementation that doesn't require custom theming, but it does rule out future use of the announcement bar for other purposes. **I think we should reach consensus that this is the right usage for the announcement bar for the foreseeable future.** 