### PR TITLE
Docs: dhis2 latest 2.37.6 version

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,7 +54,7 @@ Now that you have installed Docker and the CLI you are ready to start up a local
 1. From the terminal, start up DHIS2 and seed the database
 
 ```shell
-d2 cluster up 2.37.0 --db-version 2.37
+d2 cluster up 2.37.6 --db-version 2.37
 --seed
 ```
 


### PR DESCRIPTION
I don't know if you'd like to use 2.38 here, but this is a suggestion to update the verion request here to 2.37.6 (latest) rather than (2.37.0).

Line: 57 change from:
d2 cluster up 2.37.0 --db-version 2.37
--seed
to:
d2 cluster up 2.37.6 --db-version 2.37
--seed

Thanks!