### PR TITLE
chore: making English language pre-selected in the Newsletter form

### DIFF
--- a/community/newsletter.mdx
+++ b/community/newsletter.mdx
@@ -70,6 +70,7 @@ You can also use the checkboxes below to indicate your preferred languages and t
                         type="checkbox"
                         name="custom_fields[EXTRA1][]"
                         value="English"
+                        checked
                     />
                     English
                 </label>


### PR DESCRIPTION
Currently, no language is pre-selected but because there are several options, the form has been updated to make English as the pre-selected language.