### PR TITLE
chore: adding a note about language preferences

### DIFF
--- a/community/newsletter.mdx
+++ b/community/newsletter.mdx
@@ -64,6 +64,8 @@ You can also use the checkboxes below to indicate your preferred languages and t
     <div>
         <div className="card__body">
             <span>Language preference:</span>
+            <div class="alert alert--info" role="alert">Please note that Developer content is primarily in English; however, selecting an additional language will allow you to receive general updates related to the selected language.</div>
+            <p></p>
             <div>
                 <label>
                     <input

--- a/community/newsletter.mdx
+++ b/community/newsletter.mdx
@@ -70,6 +70,7 @@ You can also use the checkboxes below to indicate your preferred languages and t
                         type="checkbox"
                         name="custom_fields[EXTRA1][]"
                         value="English"
+                        checked
                     />
                     English
                 </label>


### PR DESCRIPTION
Added a note to explain the reason for having multiple language options in the newsletter sign-up form. The current form doesn't explain that the language selection is not directly related to developer updates as the developer content is primiarly in English but the language options are for those interested in receiving general updates related to the languages of their selection.