### PR TITLE
feat: App Competition Winners page

### DIFF
--- a/community/app-winners.mdx
+++ b/community/app-winners.mdx
@@ -1,0 +1,8 @@
+---
+id: app-winners
+title: App Competition Winners
+---
+
+import AppWinners from '@site/src/AppWinners/AppWinners';
+
+<AppWinners />

--- a/sidebarsCommunity.js
+++ b/sidebarsCommunity.js
@@ -3,6 +3,7 @@ module.exports = {
         'support',
         'stay-connected',
         'newsletter',
+        'app-winners',
         'meetups',
         {
             type: 'category',

--- a/src/AppWinners/AppWinners.js
+++ b/src/AppWinners/AppWinners.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import Winners from './Winners.js';
+import Year2023 from './Year2023.js';
+import Year2022 from './Year2022.js';
+import Year2021 from './Year2021.js';
+import Year2020 from './Year2020.js';
+
+class AppWinners extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            display: 'Winners',
+            /* Add a new year for each new year */
+            winnersList: {
+                2023: Year2023,
+                2022: Year2022,
+                2021: Year2021,
+                2020: Year2020
+            },
+            className: 'tabs__item--active'
+        };
+    }
+
+    handleNavClick = (component, event) => {
+        this.setState({ display: component });
+        const tabs = document.querySelectorAll('.tabs__item');
+        tabs.forEach(tab => tab.classList.remove(this.state.className));
+        event.currentTarget.parentNode.classList.add(this.state.className);
+    }
+
+    render() {
+        const { display, winnersList } = this.state;
+        const Year = winnersList[display] ? winnersList[display] : Winners;
+        return (
+            <div id="wrapper">
+                <ul className="tabs tabs--block">
+                    {/*
+                    Add a new li for each new year
+                    When years get too many, suggestion to leave older years in a Dropdown at the end such as (https://infima.dev/docs/components/dropdown)
+                    */}
+                    <li className="tabs__item tabs__item--active"><a href="#winnersMain" onClick={(event) => this.handleNavClick('Winners', event)}><span>App Competition</span></a></li>
+                    <li className="tabs__item"><a href="#2023" onClick={(event) => this.handleNavClick('2023', event)}><span>2023</span></a></li>
+                    <li className="tabs__item"><a href="#2022" onClick={(event) => this.handleNavClick('2022', event)}><span>2022</span></a></li>
+                    <li className="tabs__item"><a href="#2021" onClick={(event) => this.handleNavClick('2021', event)}><span>2021</span></a></li>
+                    <li className="tabs__item"><a href="#2020" onClick={(event) => this.handleNavClick('2020', event)}><span>2020</span></a></li>
+                </ul>
+                <div id="main">
+                    <Year />
+                </div>
+            </div>
+        );
+    }
+}
+
+export default AppWinners;

--- a/src/AppWinners/Winners.js
+++ b/src/AppWinners/Winners.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+
+class Winners extends Component {
+    render() {
+        return (
+            <div className="container">
+                <div className="row">
+                    <div className="col">
+                        <h2 className="heading">The DHIS2 App Competition</h2>
+                        <p>The app competition has been and is one of the most important events for the DHIS2 Developers during the DHIS2 Annual Conference. Each year the developers in the DHIS2 Community are asked to submit their applications and a number of finalists are selected by the DHIS2 core-team. During the DHIS2 Annual Conference the voting is open for all the community to vote for the best app. ... (draft description)</p>
+                        <div className="alert alert--info">App Competition submissions for DHIS2 Annual Conference 2024 will be open in May 2024 after an announcement release</div>
+                    </div>
+                    </div>
+                <div className="row">
+                <h2 className="heading padding-top--lg">The DHIS2 App Competition Winners Badge</h2>
+                    <div className="col col--6 padding-top--lg">
+                        <img src="https://dhis2.b-cdn.net/uploads/default/original/3X/e/c/ec15f88a16f7560850388cd26dfa9455c84575f4.png" alt="Badge" className="thumbnail" />
+                        <p>App Winner Badge (Web)</p>
+                        <a href="https://community.dhis2.org/badges/110/web-app-winner" className="button"><span class="badge badge--secondary padding--md">View all badge winners</span></a>
+                    </div>
+                    <div className="col col--6 padding-top--lg">
+                        <img src="https://dhis2.b-cdn.net/uploads/default/original/3X/7/f/7fc3c670a8eae17016b22d03857be427809cce54.png" alt="Badge" className="thumbnail" />
+                        <p>App Winner Badge (Android)</p>
+                        <a href="https://community.dhis2.org/badges/111/android-app-winner" className="button"><span class="badge badge--secondary padding--md">View all badge winners</span></a>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default Winners

--- a/src/AppWinners/Year2020.js
+++ b/src/AppWinners/Year2020.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+
+class Year2020 extends Component {
+    render() {
+        return (
+            <div className="row row--no-gutters">
+                <div className="col">
+                    <div className="col-demo">
+                        <div className="card-demo">
+                            <div className="card">
+                                <div className="hero hero--primary" style={{ height: '25rem' }}>
+                                    <div className="container">
+                                        <h1 className="hero__title">App Name</h1>
+                                        <p className="hero__subtitle">App Short Description</p>
+                                    </div>
+                                </div>
+                                <div className="card__header">
+                                    <div className="avatar">
+                                        <img
+                                            className="avatar__photo"
+                                            src="https://ugc.padletcdn.com/uploads/padlet-uploads/1227681803/59a58d56de2d9cd7c6d1e309fd82ee33/image.png?token=ZVIgB0nBlvXUZ5xB94h9X2LN_y0Z16SEeoDReR6kmVleP0bwALRAC6ZyClXNkOAHlqgCJuh_4pD_eqRZQ9ZYcEljkK4__Ny3yc8nUYIu64ggVzJWDUdjt0ZyNnxD97mYf7srsHQKJdmKrjwIYIbBD1PLItxYLiXseGUfqCJgoTVx7yMWetEVk14FLxuEorqvD1is17pxkSEGdI1HbMlUhkxrUwdGzwJynax3ulyOW3Q=" alt="Eric Chingalo" />
+                                        <div className="avatar__intro">
+                                            <div className="avatar__name">Winner Name</div>
+                                            <small className="avatar__subtitle">
+                                                Description such as title, or organization name
+                                            </small>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="card__footer">
+                                    <div className="button-group button-group--block">
+                                        <button className="button button--secondary">Profile</button>
+                                        <button className="button button--secondary">App Description</button>
+                                        <button className="button button--secondary">Download</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        )
+    }
+}
+
+export default Year2020;

--- a/src/AppWinners/Year2021.js
+++ b/src/AppWinners/Year2021.js
@@ -1,0 +1,45 @@
+import React, {Component} from 'react';
+
+class Year2021 extends Component {
+    render() {
+        return(
+            <div className="row row--no-gutters">
+            <div className="col">
+                <div className="col-demo">
+                    <div className="card-demo">
+                        <div className="card">
+                            <div className="hero hero--primary" style={{height: '25rem'}}>
+                                <div className="container">
+                                    <h1 className="hero__title">App Name</h1>
+                                    <p className="hero__subtitle">App Short Description</p>
+                                </div>
+                            </div>
+                            <div className="card__header">
+                                <div className="avatar">
+                                    <img
+                                        className="avatar__photo"
+                                        src="https://ugc.padletcdn.com/uploads/padlet-uploads/1227681803/59a58d56de2d9cd7c6d1e309fd82ee33/image.png?token=ZVIgB0nBlvXUZ5xB94h9X2LN_y0Z16SEeoDReR6kmVleP0bwALRAC6ZyClXNkOAHlqgCJuh_4pD_eqRZQ9ZYcEljkK4__Ny3yc8nUYIu64ggVzJWDUdjt0ZyNnxD97mYf7srsHQKJdmKrjwIYIbBD1PLItxYLiXseGUfqCJgoTVx7yMWetEVk14FLxuEorqvD1is17pxkSEGdI1HbMlUhkxrUwdGzwJynax3ulyOW3Q=" alt="Eric Chingalo" />
+                                    <div className="avatar__intro">
+                                        <div className="avatar__name">Winner Name</div>
+                                        <small className="avatar__subtitle">
+                                            Description such as title, or organization name
+                                        </small>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="card__footer">
+                                <div className="button-group button-group--block">
+                                    <button className="button button--secondary">Profile</button>
+                                    <button className="button button--secondary">App Description</button>
+                                    <button className="button button--secondary">Download</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )}
+}
+
+export default Year2021

--- a/src/AppWinners/Year2022.js
+++ b/src/AppWinners/Year2022.js
@@ -1,0 +1,45 @@
+import React, {Component} from 'react';
+
+class Year2022 extends Component {
+    render() {
+        return(
+        <div className="row row--no-gutters">
+        <div className="col">
+            <div className="col-demo">
+                <div className="card-demo">
+                    <div className="card">
+                        <div className="hero hero--primary" style={{height: '25rem'}}>
+                            <div className="container">
+                                <h1 className="hero__title">App Name</h1>
+                                <p className="hero__subtitle">App Short Description</p>
+                            </div>
+                        </div>
+                        <div className="card__header">
+                            <div className="avatar">
+                                <img
+                                    className="avatar__photo"
+                                    src="https://ugc.padletcdn.com/uploads/padlet-uploads/1227681803/59a58d56de2d9cd7c6d1e309fd82ee33/image.png?token=ZVIgB0nBlvXUZ5xB94h9X2LN_y0Z16SEeoDReR6kmVleP0bwALRAC6ZyClXNkOAHlqgCJuh_4pD_eqRZQ9ZYcEljkK4__Ny3yc8nUYIu64ggVzJWDUdjt0ZyNnxD97mYf7srsHQKJdmKrjwIYIbBD1PLItxYLiXseGUfqCJgoTVx7yMWetEVk14FLxuEorqvD1is17pxkSEGdI1HbMlUhkxrUwdGzwJynax3ulyOW3Q=" alt="Eric Chingalo" />
+                                <div className="avatar__intro">
+                                    <div className="avatar__name">Winner Name</div>
+                                    <small className="avatar__subtitle">
+                                        Description such as title, or organization name
+                                    </small>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="card__footer">
+                            <div className="button-group button-group--block">
+                                <button className="button button--secondary">Profile</button>
+                                <button className="button button--secondary">App Description</button>
+                                <button className="button button--secondary">Download</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+        )}
+}
+
+export default Year2022;

--- a/src/AppWinners/Year2023.js
+++ b/src/AppWinners/Year2023.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+
+class One extends Component {
+    render() {
+        return (
+            <div className="row row--no-gutters">
+                <div className="col">
+                    <div className="col-demo">
+                        <div className="card-demo">
+                            <div className="card">
+                                <div className="hero hero--primary" style={{height: '25rem'}}>
+                                    <div className="container">
+                                        <h1 className="hero__title">DHIS2 Analytics Messenger</h1>
+                                        <p className="hero__subtitle">DHIS2 Annaul Conference 2023 App Competition Winner</p>
+                                    </div>
+                                </div>
+                                <div className="card__header">
+                                    <div className="avatar">
+                                        <img
+                                            className="avatar__photo"
+                                            src="https://ugc.padletcdn.com/uploads/padlet-uploads/1227681803/bb64a7d4b81bf069bb57753cd4822a7f/EricChingalo.jpg?token=ZVIgB0nBlvXUZ5xB94h9X2LN_y0Z16SEeoDReR6kmVleP0bwALRAC6ZyClXNkOAHlqgCJuh_4pD_eqRZQ9ZYcEljkK4__Ny3yc8nUYIu64ggVzJWDUdjt0ZyNnxD97mYtjRx3Jd39JjIfVMJVnSzPUhDlJOvEUFLXgWWM1eRjsWSuxPs_CQYPBH2ZIqU6HFb5S-aWhaNgZ_ylKEp-igPRN04jQ9q5A1kzQRrEwzjRJ2PqLyp1qY7Gw9horI-qJYx" alt="Eric Chingalo" />
+                                        <div className="avatar__intro">
+                                            <div className="avatar__name">Eric Chingalo</div>
+                                            <small className="avatar__subtitle">
+                                                HISP Tanzania
+                                            </small>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="card__footer">
+                                    <div className="button-group button-group--block">
+                                        <button className="button button--secondary">Profile</button>
+                                        <button className="button button--secondary">App Description</button>
+                                        <button className="button button--secondary">Download</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default One


### PR DESCRIPTION
Added a new Community page "App Competition Winners":

- Created app-winners.mdx and added it to sidebarsCommunity.js for the sidebar
- Structured the page for easy maintenance by separating "years" into components
- Used Infima classNames for styling
- Showed description of the App Competition and space for badges (100% Draft)
- Created a basic template for 2023 to show App Name, year, and links to Winner's CoP profile, Description of the app (CoP Post), and the download link to the App Hub

This is a first draft to receive comments from the team.

Note: images are external links for now, I'm trying to figure out how to use resources on Docusaurus.

Thanks! 🙂👍