### PR TITLE
fix: show developer meetup page again

### DIFF
--- a/src/MeetupAttendees/BadgeList.js
+++ b/src/MeetupAttendees/BadgeList.js
@@ -1,39 +1,61 @@
-import React from 'react';
-import UserBadge from './UserBadge';
+import React from 'react'
+import UserBadge from './UserBadge'
 import './badges.css'
 
 export const BadgeList = ({ attendees, info }) => {
-  return (
-    <>
-      <section className="BadgeInfo">
-        <div className="avatar avatar--vertical">
-          <img className="avatar__photo avatar__photo--xl" src={info.image_url} />
-          <div className="avatar__intro">
-            <div className="avatar__name">{info.name} Badge</div>
-            <small className="avatar__subtitle">{info.description}</small>
-            <div className="alert alert--info">This badge has been granted <strong>{info.grant_count}</strong> times!</div>
-          </div>
-        </div>
-      </section>
-      <div className="badgeArea">
-        {
-          attendees.map((user, i) => {
-            if (user.username != "System-Academy") {
-              return (
-                <UserBadge key={user.id} username={
-                  user.name ? user.name.split(' ').length > 2 ?
-                    user.name.split(' ')[0] + ' ' + user.name.split(' ')[user.name.split(' ').length - 2] + ' ' + user.name.split(' ')[user.name.split(' ').length - 1] :
-                    user.name : user.username
-                }
-                  img={"https://dhis2.b-cdn.net/" + user.avatar_template.replace('{size}', '120')}
-                  link={"https://community.dhis2.org" + user.assign_path.replace('/activity/assigned', '')}
-                />)
-            }
-            else {
-              return ''
-            }
-          })}
-      </div>
-    </>
-  )
-};
+    return (
+        <>
+            <section className="BadgeInfo">
+                <div className="avatar avatar--vertical">
+                    <img
+                        className="avatar__photo avatar__photo--xl"
+                        src={info.image_url}
+                    />
+                    <div className="avatar__intro">
+                        <div className="avatar__name">{info.name} Badge</div>
+                        <small className="avatar__subtitle">
+                            {info.description}
+                        </small>
+                        <div className="alert alert--info">
+                            This badge has been granted{' '}
+                            <strong>{info.grant_count}</strong> times!
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <div className="badgeArea">
+                {attendees.map((user, i) => {
+                    if (user.username != 'System-Academy') {
+                        return (
+                            <UserBadge
+                                key={user.id}
+                                username={
+                                    user.name
+                                        ? ((parts) =>
+                                              parts.length > 2
+                                                  ? `${parts[0]} ${
+                                                        parts[parts.length - 1]
+                                                    }`
+                                                  : user.name)(
+                                              user.name.split(' ')
+                                          )
+                                        : user.username
+                                }
+                                img={
+                                    'https://dhis2.b-cdn.net/' +
+                                    user.avatar_template.replace(
+                                        '{size}',
+                                        '120'
+                                    )
+                                }
+                                link={`https://community.dhis2.org/badges/118/developer-meetup-attendee?username=${user.username}`}
+                            />
+                        )
+                    } else {
+                        return ''
+                    }
+                })}
+            </div>
+        </>
+    )
+}


### PR DESCRIPTION
The meetup page broke due to update in discourse, this fixes it. 

But due to `CORS` the API request is failing (it's working localhost) so in order to test it properly we'd need to add the Netlify.app domain to CORS in Discourse (I do not have permission)

https://meta.discourse.org/t/setup-cross-origin-resource-sharing-cors/270819