### PR TITLE
fix: add CustomDataProvider docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -192,6 +192,7 @@ module.exports = {
                                         'app-runtime/advanced/offline/useOnlineStatus',
                                     ],
                                 },
+                                'app-runtime/advanced/CustomDataProvider',
                                 'app-runtime/advanced/services',
                                 'app-runtime/advanced/DataEngine',
                                 'app-runtime/advanced/DataEngineLinks',


### PR DESCRIPTION
This adds [CustomDataProvider docs ](https://github.com/dhis2/app-runtime/blob/master/docs/advanced/CustomDataProvider.md) into the developer portal documentation. The CustomDataProvider is used for setting up tests, e.g. it's referenced in the sample test that new apps are initialized with (https://github.com/dhis2/app-platform/blob/master/cli/config/init.App.test.js#L9)