### PR TITLE
chore:add json to languages for highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ module.exports = {
     projectName: 'developer-portal',
     themeConfig: {
         prism: {
-            additionalLanguages: ['java','yaml'],
+            additionalLanguages: ['java', 'yaml', 'json'],
         },
         navbar: {
             logo: {


### PR DESCRIPTION
JSON was missing from the language highlighter and is used in capture plugin docs.