### PR TITLE
docs: add link to vite config extensions in sidebar

### DIFF
--- a/sidebarsReferences.js
+++ b/sidebarsReferences.js
@@ -153,6 +153,7 @@ module.exports = {
                         'app-platform/config/types',
                         'app-platform/config/d2-config-js-reference',
                         'app-platform/config/environment',
+                        'app-platform/config/extending-vite-config',
                     ],
                 },
                 {


### PR DESCRIPTION
[LIBS-706](https://dhis2.atlassian.net/browse/LIBS-706)

<img width="1296" height="839" alt="Screenshot 2025-07-28 at 19 38 17" src="https://github.com/user-attachments/assets/e9837543-29c6-443b-adac-87be7900014d" />


[LIBS-706]: https://dhis2.atlassian.net/browse/LIBS-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ